### PR TITLE
add v130 migration, skip for sqlite as default is already accounted f…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,4 @@ Thumbs.db
 
 # Copied upstream test fixtures (binary files used via filesystem paths)
 src/test/resources/cbx/
+.claude/settings.local.json

--- a/src/main/resources/db/changelog/changelogs/130-add-book-per-file-organization-mode.yaml
+++ b/src/main/resources/db/changelog/changelogs/130-add-book-per-file-organization-mode.yaml
@@ -1,0 +1,16 @@
+databaseChangeLog:
+  - changeSet:
+      id: add-book-per-file-organization-mode
+      author: https://github.com/booklore-app/booklore/pull/3203
+      dbms: "!sqlite"
+      preConditions:
+        - onFail: HALT
+        - columnExists:
+            tableName: library
+            columnName: organization_mode
+      changes:
+        - addDefaultValue:
+            columnDataType: varchar(255)
+            columnName: organization_mode
+            defaultValue: BOOK_PER_FILE
+            tableName: library

--- a/src/main/resources/db/changelog/changelogs/130-add-book-per-file-organization-mode.yaml
+++ b/src/main/resources/db/changelog/changelogs/130-add-book-per-file-organization-mode.yaml
@@ -10,7 +10,7 @@ databaseChangeLog:
             columnName: organization_mode
       changes:
         - addDefaultValue:
-            columnDataType: varchar(255)
+            columnDataType: varchar(50)
             columnName: organization_mode
             defaultValue: BOOK_PER_FILE
             tableName: library

--- a/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -3,3 +3,5 @@ databaseChangeLog:
       file: db/changelog/changelogs/001-baseline-schema.yaml
   - include:
       file: db/changelog/changelogs/002-baseline-seed-data.yaml
+  - include:
+      file: db/changelog/changelogs/130-add-book-per-file-organization-mode.yaml


### PR DESCRIPTION
…or in code and would require costly table recreation